### PR TITLE
Bump library versions

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -45,8 +45,8 @@
             </feature>
         </config-file>
 
-        <framework src="com.google.android.gms:play-services-maps:9.8.0" />
-        <framework src="com.google.android.gms:play-services-location:9.8.0" />
+        <framework src="com.google.android.gms:play-services-maps:11.8.+" />
+        <framework src="com.google.android.gms:play-services-location:11.8.+" />
 
         <!-- plugin src files -->
         <source-file src="src/android/plugin/google/maps/AsyncLicenseInfo.java" target-dir="src/plugin/google/maps" />


### PR DESCRIPTION
Raised the versions of play-services-maps and play-services-location.

As suggested [here](https://github.com/OneSignal/OneSignal-Cordova-SDK/issues/297#issuecomment-363731648). Not sure if you guys tested this, so decided to point it out.